### PR TITLE
Feat/toc component

### DIFF
--- a/src/components/Posts/table-of-content.tsx
+++ b/src/components/Posts/table-of-content.tsx
@@ -1,6 +1,6 @@
-import classNames from 'classnames';
+import useHeadingsDOM from '@/hooks/useHeadingsDOM';
 import { TableOfContentsEntry } from 'notion-utils';
-import { useState } from 'react';
+import { MouseEvent, useState } from 'react';
 import styles from './posts.module.scss';
 
 interface Props {
@@ -8,14 +8,23 @@ interface Props {
 }
 
 const TableOfContent = ({ toc }: Props) => {
-  const [current, setCurrent] = useState(0);
+  const [current, setCurrent] = useState<number | null>(null);
+  const { headings } = useHeadingsDOM();
 
   const formattedId = (id: string) => {
     return id.replaceAll('-', '');
   };
 
-  const handleNavigateToSection = (idx: number) => {
+  const handleNavigateToSection = (
+    e: MouseEvent<HTMLAnchorElement>,
+    idx: number
+  ) => {
+    e.preventDefault();
     setCurrent(idx);
+    headings[idx].scrollIntoView({
+      behavior: 'smooth',
+      block: 'start'
+    });
   };
 
   return (
@@ -23,12 +32,12 @@ const TableOfContent = ({ toc }: Props) => {
       <ul>
         {toc &&
           toc.map((x, idx) => {
-            const isActive = classNames({ [styles.active]: current === idx });
+            const activeClass = current === idx ? styles.active : '';
             return (
-              <li key={x.id} className={isActive}>
+              <li key={x.id} className={activeClass}>
                 <a
                   href={`#${formattedId(x.id)}`}
-                  onClick={() => handleNavigateToSection(idx)}
+                  onClick={e => handleNavigateToSection(e, idx)}
                 >
                   {x.text}
                 </a>

--- a/src/hooks/useHeadingsDOM.tsx
+++ b/src/hooks/useHeadingsDOM.tsx
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+
+const useHeadingsDOM = () => {
+  const [headings, setHeadings] = useState<Element[]>([]);
+
+  useEffect(() => {
+    setHeadings(Array.from(document.querySelectorAll('h2, h3')));
+  }, []);
+
+  return { headings };
+};
+
+export default useHeadingsDOM;


### PR DESCRIPTION
관련 이슈:
closes #8, closes #3 

## 작업 내용
- toc 클릭시 해당 섹션으로 스크롤하기 -> `node.scrollIntoView` 사용
- 페이지 스크롤시 toc 같이 highlight하기 -> `IntersectionObserver` 사용

## 이슈 사항 & 느낀점
- 블로그 컨텐츠는 `<NotionRenderer>`를 통해 그려지다 보니 `useRef`를 이용해 DOM을 접근할 수 없었다. 그래서 `useHeadingsDOM` 훅은 `document.querySelectorAll()`을 `useEffect`으로 감싸 컴포넌트가 마운트 된 후 h1, h2 태그들을 배열에 담는다.