### PR TITLE
Feat/filter posts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,7 @@
   },
   "rules": {
     "prettier/prettier": "warn",
-    "no-console": "warn",
+    "no-console": "off",
     "react/react-in-jsx-scope": "off",
     "@typescript-eslint/no-unused-vars": "warn",
     "@typescript-eslint/no-explicit-any": "error",

--- a/src/components/Home/home.module.scss
+++ b/src/components/Home/home.module.scss
@@ -64,4 +64,14 @@
     gap: 1rem;
     align-items: flex-start;
   }
+
+  .resetFiltersBtn {
+    padding-left: 0.5rem;
+    font-size: 1.2rem;
+    color: var(--text-light);
+
+    &:hover {
+      color: var(--text-sub);
+    }
+  }
 }

--- a/src/components/Home/post-grid.tsx
+++ b/src/components/Home/post-grid.tsx
@@ -1,13 +1,21 @@
 import { PostResponse } from '@/types/post';
 import PostCard from './post-card';
 import styles from './home.module.scss';
+import { useFilters } from '@/context/filters';
 
 const PostGrid = ({ posts }: { posts: PostResponse[] }) => {
+  const { filters } = useFilters();
+
+  const filteredPosts =
+    filters.length > 0
+      ? posts.filter(post => post.tags.find(tag => filters.includes(tag.name)))
+      : posts;
+
   return (
     <>
-      <p className={styles.countPosts}>{posts.length} posts</p>
+      <p className={styles.countPosts}>{filteredPosts.length} posts</p>
       <ul className={styles.postGrid}>
-        {posts.map(post => (
+        {filteredPosts.map(post => (
           <PostCard {...post} key={post.slug} />
         ))}
       </ul>

--- a/src/components/Home/tag-list.tsx
+++ b/src/components/Home/tag-list.tsx
@@ -1,24 +1,16 @@
+import { useFilters } from '@/context/filters';
 import { TagResponse } from '@/types/tag';
-import { useState } from 'react';
 import Tag from '../base/Tag';
 import styles from './home.module.scss';
 
 const TagList = ({ tags }: { tags: TagResponse[] }) => {
-  const [filters, setFilters] = useState<string[]>([]);
-
-  const handleSelect = (tag: string) => {
-    if (filters.includes(tag)) {
-      setFilters(filters.filter(x => x !== tag));
-    } else {
-      setFilters([...filters, tag]);
-    }
-  };
+  const { filters, setFilters, resetFilters } = useFilters();
 
   return (
     <div className={styles.tagList}>
       <ul>
         {tags.map(tag => (
-          <button key={tag.id} onClick={() => handleSelect(tag.name)}>
+          <button key={tag.id} onClick={() => setFilters(tag.name)}>
             <Tag
               name={tag.name}
               fill={filters.includes(tag.name)}
@@ -26,6 +18,11 @@ const TagList = ({ tags }: { tags: TagResponse[] }) => {
             />
           </button>
         ))}
+        {filters.length > 0 && (
+          <button className={styles.resetFiltersBtn} onClick={resetFilters}>
+            unselect all
+          </button>
+        )}
       </ul>
     </div>
   );

--- a/src/components/Home/tag-list.tsx
+++ b/src/components/Home/tag-list.tsx
@@ -1,10 +1,9 @@
+import { TagResponse } from '@/types/tag';
 import { useState } from 'react';
 import Tag from '../base/Tag';
 import styles from './home.module.scss';
 
-const tags = ['Next', 'React', 'JS', 'TS', 'HTML'];
-
-const TagList = () => {
+const TagList = ({ tags }: { tags: TagResponse[] }) => {
   const [filters, setFilters] = useState<string[]>([]);
 
   const handleSelect = (tag: string) => {
@@ -19,8 +18,12 @@ const TagList = () => {
     <div className={styles.tagList}>
       <ul>
         {tags.map(tag => (
-          <button key={tag} onClick={() => handleSelect(tag)}>
-            <Tag name={tag} fill={filters.includes(tag)} size="large" />
+          <button key={tag.id} onClick={() => handleSelect(tag.name)}>
+            <Tag
+              name={tag.name}
+              fill={filters.includes(tag.name)}
+              size="large"
+            />
           </button>
         ))}
       </ul>

--- a/src/components/Posts/notion-content.tsx
+++ b/src/components/Posts/notion-content.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import Image from 'next/image';
 import styles from './posts.module.scss';
-import { Tag as TTag } from '@/types/post';
+import { TagResponse } from '@/types/tag';
 import Tag from '../base/Tag';
 
 const Code = dynamic(
@@ -21,7 +21,7 @@ const Equation = dynamic(() =>
 interface Props {
   recordMap: ExtendedRecordMap;
   title: string;
-  tags: TTag[];
+  tags: TagResponse[];
   date: string;
 }
 

--- a/src/context/filters.tsx
+++ b/src/context/filters.tsx
@@ -1,0 +1,33 @@
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+type TFiltersContext = {
+  filters: string[];
+  setFilters: (tag: string) => void;
+  resetFilters: () => void;
+};
+
+export const FiltersContext = createContext<TFiltersContext | null>(null);
+export const useFilters = () => useContext(FiltersContext) as TFiltersContext;
+
+const FiltersProvider = ({ children }: { children: ReactNode }) => {
+  const [filters, setNextFilters] = useState<string[]>([]);
+
+  const setFilters = (tag: string) => {
+    if (filters.includes(tag)) {
+      setNextFilters(filters.filter(x => x !== tag));
+    } else {
+      setNextFilters([...filters, tag]);
+    }
+  };
+
+  const resetFilters = () => {
+    setNextFilters([]);
+  };
+  return (
+    <FiltersContext.Provider value={{ filters, setFilters, resetFilters }}>
+      {children}
+    </FiltersContext.Provider>
+  );
+};
+
+export default FiltersProvider;

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -1,4 +1,5 @@
 import { ResultItem } from '@/types/post';
+import { TagResult } from '@/types/tag';
 import { Client } from '@notionhq/client';
 import { NotionAPI } from 'notion-client';
 
@@ -7,6 +8,16 @@ const notionClient = new Client({
 });
 const databaseId = process.env.NOTION_DATABASE_ID as string;
 const notionReact = new NotionAPI();
+
+export const getDatabaseTags = async () => {
+  const response = (await notionClient.databases.retrieve({
+    database_id: databaseId
+  })) as TagResult;
+
+  const tags = response.properties.Tags.multi_select.options;
+
+  return tags;
+};
 
 export const getAllPosts = async () => {
   const response = await notionClient.databases.query({

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,15 @@
 import { styles, PostGrid, TagList } from '@/components/Home';
 import { InferGetStaticPropsType } from 'next';
-import { getAllPosts } from '@/lib/notion';
+import { getAllPosts, getDatabaseTags } from '@/lib/notion';
 
 const HomePage = ({
-  posts
+  posts,
+  tags
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   return (
     <div className={styles.home}>
       <PostGrid posts={posts} />
-      <TagList />
+      <TagList tags={tags} />
     </div>
   );
 };
@@ -17,10 +18,12 @@ export default HomePage;
 
 export async function getStaticProps() {
   const posts = await getAllPosts();
+  const tags = await getDatabaseTags();
 
   return {
     props: {
-      posts
+      posts,
+      tags
     }
   };
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,16 +1,19 @@
 import { styles, PostGrid, TagList } from '@/components/Home';
 import { InferGetStaticPropsType } from 'next';
 import { getAllPosts, getDatabaseTags } from '@/lib/notion';
+import FiltersProvider from '@/context/filters';
 
 const HomePage = ({
   posts,
   tags
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   return (
-    <div className={styles.home}>
-      <PostGrid posts={posts} />
-      <TagList tags={tags} />
-    </div>
+    <FiltersProvider>
+      <div className={styles.home}>
+        <PostGrid posts={posts} />
+        <TagList tags={tags} />
+      </div>
+    </FiltersProvider>
   );
 };
 

--- a/src/types/post.d.ts
+++ b/src/types/post.d.ts
@@ -1,14 +1,9 @@
 import { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints';
-
-export interface Tag {
-  id: string;
-  name: string;
-  color: string;
-}
+import { TagResponse } from './tag';
 
 export interface PostResponse {
   title: string;
-  tags: Tag[];
+  tags: TagResponse[];
   date: string;
   slug: string;
   id: string;
@@ -19,19 +14,18 @@ export type PostResult = Extract<
   { properties: Record<string, unknown> }
 >;
 
+export type ExtractedValue<T, K, U> = T extends K
+  ? Extract<U, { type: T }>
+  : never;
+
 type PropertyValueMap = PostResult['properties'];
 type PropertyValue = PropertyValueMap[string];
 type PropertyValueType = PropertyValue['type'];
 
-export type ExtractedPropertyValue<T extends PropertyValueType> = Extract<
-  PropertyValue,
-  { type: T }
->;
-
 export type ResultItem = PostResult & {
   properties: {
-    Name: ExtractedPropertyValue<'title'>;
-    Tags: ExtractedPropertyValue<'multi_select'>;
+    Name: ExtractedValue<'title', PropertyValueType, PropertyValue>;
+    Tags: ExtractedValue<'multi_select', PropertyValueType, PropertyValue>;
     Slug: {
       formula: {
         string: string;

--- a/src/types/tag.d.ts
+++ b/src/types/tag.d.ts
@@ -1,0 +1,18 @@
+import { GetDatabaseResponse } from '@notionhq/client/build/src/api-endpoints';
+import { ExtractedValue } from './post';
+
+export interface TagResponse {
+  id: string;
+  name: string;
+  color: string;
+}
+
+type PropertyValueMap = GetDatabaseResponse['properties'];
+type PropertyValue = PropertyValueMap[string];
+type PropertyValueType = PropertyValue['type'];
+
+export type TagResult = GetDatabaseResponse & {
+  properties: {
+    Tags: ExtractedValue<'multi_select', PropertyValueType, PropertyValue>;
+  };
+};


### PR DESCRIPTION
관련 이슈:
closes #2 

## 작업 내용
- 기존에는 사용하는 태그를 하드코딩해서 `TagList`를 렌더링 했으며 실제 db와 싱크를 맞추기 위해 노션에서 태그 (multi-select 속성) 정보 가져오기
- `TagList`에서 클릭한 필터 정보를 `Context`로 관리해 `PostGrid`에서 정보 consume해 posts 필터링 하기

## 이슈 사항 & 느낀점
- 노션 api의 깊이 nested되어 있는 union type들 때문에 타입 `TagResult`를 가져오기 위해 `Extract<>`를 사용했고, boilerplate code를 줄이기 위해 커스텀 utility type을 구현했다